### PR TITLE
feat!: move additional router options to object

### DIFF
--- a/examples/nested_routes.ts
+++ b/examples/nested_routes.ts
@@ -1,5 +1,5 @@
-import { serve } from "https://deno.land/std@0.173.0/http/server.ts";
-import { router } from "../mod.ts";
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { router } from "https://deno.land/x/rutt/mod.ts";
 
 await serve(
   router({

--- a/examples/parameters.ts
+++ b/examples/parameters.ts
@@ -3,6 +3,7 @@ import { router } from "https://deno.land/x/rutt/mod.ts";
 
 await serve(
   router({
-    "/": (_req) => new Response("Hello world!", { status: 200 }),
+    "/hello/:name": (_req, _, { name }) =>
+      new Response(`Hello ${name}`, { status: 200 }),
   }),
 );

--- a/mod.ts
+++ b/mod.ts
@@ -112,12 +112,12 @@ export interface RouterOptions<T> {
 /**
  * A known HTTP method.
  */
-export type KnownMethod = typeof KnownMethods[number];
+export type KnownMethod = typeof knownMethods[number];
 
 /**
  * All known HTTP methods.
  */
-export const KnownMethods = [
+export const knownMethods = [
   "GET",
   "HEAD",
   "POST",
@@ -171,7 +171,7 @@ export function defaultUnknownMethodHandler(
   });
 }
 
-const knownMethodRegex = new RegExp(`(?<=^(?:${KnownMethods.join("|")}))@`);
+const knownMethodRegex = new RegExp(`(?<=^(?:${knownMethods.join("|")}))@`);
 
 function joinPaths(a: string, b: string): string {
   if (a.endsWith("/")) {

--- a/mod.ts
+++ b/mod.ts
@@ -4,6 +4,18 @@
  * extended type of the web-standard {@link URLPattern} to provide fast and
  * easy route matching.
  *
+ * @example
+ * ```ts
+ * import { serve } from "https://deno.land/std/http/server.ts";
+ * import { router } from "https://deno.land/x/rutt/mod.ts";
+ *
+ * await serve(
+ *   router({
+ *     "/": (_req) => new Response("Hello world!", { status: 200 }),
+ *   }),
+ * );
+ * ```
+ *
  * @module
  */
 
@@ -156,7 +168,7 @@ export function defaultErrorHandler(
 /**
  * The default unknown method handler for the router. By default it responds
  * with `null` body, a status of 405 and the `Accept` header set to all
- * {@link KnownMethods known methods}.
+ * {@link KnownMethod known methods}.
  */
 export function defaultUnknownMethodHandler(
   _req: Request,
@@ -226,7 +238,9 @@ export function buildInternalRoutes<T = unknown>(
 }
 
 /**
- * A simple and tiny router for deno
+ * A simple and tiny router for deno. This function provides a way of
+ * constructing a HTTP request handler for the provided {@link routes} and any
+ * provided {@link RouterOptions}.
  *
  * @example
  * ```ts

--- a/test.ts
+++ b/test.ts
@@ -4,7 +4,7 @@ import {
   assertEquals,
   assertIsError,
 } from "https://deno.land/std@0.177.0/testing/asserts.ts";
-import { METHODS, router } from "./mod.ts";
+import { KnownMethods, router } from "./mod.ts";
 
 const TEST_CONN_INFO: ConnInfo = {
   localAddr: {
@@ -183,7 +183,7 @@ Deno.test("handlers", async ({ step }) => {
             assert(Array.isArray(knownMethods));
             assert(
               knownMethods.every((method) =>
-                METHODS.includes(
+                KnownMethods.includes(
                   method as
                     | "GET"
                     | "HEAD"

--- a/test.ts
+++ b/test.ts
@@ -4,7 +4,7 @@ import {
   assertEquals,
   assertIsError,
 } from "https://deno.land/std@0.177.0/testing/asserts.ts";
-import { KnownMethods, router } from "./mod.ts";
+import { router } from "./mod.ts";
 
 const TEST_CONN_INFO: ConnInfo = {
   localAddr: {
@@ -182,18 +182,7 @@ Deno.test("handlers", async ({ step }) => {
           unknownMethodHandler: (_req, _ctx, knownMethods) => {
             assert(Array.isArray(knownMethods));
             assert(
-              knownMethods.every((method) =>
-                KnownMethods.includes(
-                  method as
-                    | "GET"
-                    | "HEAD"
-                    | "POST"
-                    | "PUT"
-                    | "DELETE"
-                    | "OPTIONS"
-                    | "PATCH",
-                )
-              ),
+              knownMethods.every((method) => knownMethods.includes(method)),
             );
             assertEquals(knownMethods, ["GET", "PATCH"]);
 


### PR DESCRIPTION
I will publish the first minor release after this has been merged. Also sneaked in a test for methods in nested routes.