### PR TITLE
feat: infer type of the URLPattern context passed to the handler

### DIFF
--- a/examples/typesafe_parameters.ts
+++ b/examples/typesafe_parameters.ts
@@ -1,0 +1,10 @@
+import { router } from "https://deno.land/x/rutt/mod.ts";
+
+await Deno.serve(
+  router({
+    "/hello/:andThisNot": (_req, _, { thisShouldBeUndefined, andThisNot }) =>
+      new Response(`Hello ${thisShouldBeUndefined} and ${andThisNot}`, {
+        status: 200,
+      }),
+  }),
+).finished;

--- a/mod.ts
+++ b/mod.ts
@@ -18,48 +18,140 @@
  * @module
  */
 
+// deno-lint-ignore no-explicit-any
+export type TemplateWildcard = any;
+
+export type RoutePath = string; // number | symbol | ;
+export type UnknownRouteNesting = Record<string, unknown>;
+
+export type EnsureString<A extends string | symbol | number> = A extends string
+  ? A
+  : "";
+export type JoinStrings<A extends string, B extends string> = `${A}${B}`;
+
+// deno-fmt-ignore formatting Split will make it unreadable
+export type Split<S extends RoutePath, D extends string> =
+  string extends S
+  ? string[]
+  : S extends ""
+    ? []
+    : S extends `${infer T}${D}${infer U}`
+      ? [T, ...Split<U, D>]
+      : [S];
+
+// deno-fmt-ignore formatting FilterAndTrimPathParamsToStringUnion will make it unreadable
+export type FilterAndTrimPathParamsToStringUnion<A extends RoutePath[], P extends string> =
+  {
+    // This "object" is an array of nevers and path segments
+    [K in keyof A]:
+      string extends A[K]
+      ? never
+      : A[K] extends ""
+        ? never
+        : A[K] extends `${P}` // when matched ":" alone - drop it
+          ? P
+          : A[K] extends `${P}${infer R}`
+            ? R
+            : never
+  }[number]; // if you get array[number] like this - TS will drop nevers and create union of strings
+
+/**
+ * ```typescript
+ *  type Path = "/api/items/:itemId/filter/:filterId"
+ *  const extracted: ExtractPathMatch<Path> = {
+ *    // TypeScript will expect itemId and filterId as defined strings here
+ *  };
+ * ```
+ */
+export type ExtractPathMatch<
+  T extends RoutePath,
+  P extends string = string,
+  S extends string = ":",
+> = Record<
+  FilterAndTrimPathParamsToStringUnion<
+    Split<T, "/">,
+    S
+  >,
+  P
+>;
+
+export type HandlerContextBase = Deno.ServeHandlerInfo;
+
 /**
  * Provides arbitrary context to {@link Handler} functions along with
  * {@link ConnInfo connection information}.
  */
-export type HandlerContext<T = unknown> = T & Deno.ServeHandlerInfo;
+export type HandlerContext<
+  HandlerContextExtra extends Record<string, TemplateWildcard> = Record<
+    string,
+    unknown
+  >,
+> = HandlerContextBase & HandlerContextExtra;
 
 /**
  * A handler for HTTP requests. Consumes a request and {@link HandlerContext}
  * and returns an optionally async response.
  */
-export type Handler<T = unknown> = (
+export type Handler<HandlerContextExtra extends HandlerContextBase> = (
   req: Request,
-  ctx: HandlerContext<T>,
+  ctx: HandlerContext<HandlerContextExtra>,
 ) => Response | Promise<Response>;
 
 /**
  * A handler type for anytime the `MatchHandler` or `other` parameter handler
  * fails
  */
-export type ErrorHandler<T = unknown> = (
+export type ErrorHandler<HandlerContextExtra extends HandlerContextBase> = (
   req: Request,
-  ctx: HandlerContext<T>,
+  ctx: HandlerContext<HandlerContextExtra>,
   err: unknown,
 ) => Response | Promise<Response>;
 
 /**
  * A handler type for anytime a method is received that is not defined
  */
-export type UnknownMethodHandler<T = unknown> = (
+export type UnknownMethodHandler<
+  HandlerContextExtra extends HandlerContextBase,
+> = (
   req: Request,
-  ctx: HandlerContext<T>,
+  ctx: HandlerContext<HandlerContextExtra>,
   knownMethods: KnownMethod[],
 ) => Response | Promise<Response>;
 
 /**
  * A handler type for a router path match which gets passed the matched values
  */
-export type MatchHandler<T = unknown> = (
+export type MatchHandler<
+  HandlerContextExtra extends HandlerContextBase,
+  _PatternMatch extends Record<string, string> = Record<string, string>,
+> = <__PatternMatch extends _PatternMatch>(
   req: Request,
-  ctx: HandlerContext<T>,
-  match: Record<string, string>,
+  ctx: HandlerContext<HandlerContextExtra>,
+  match: _PatternMatch,
 ) => Response | Promise<Response>;
+
+export type RoutesBranch<
+  RoutesWithHandlers extends UnknownRouteNesting,
+  HandlerContextExtra extends HandlerContextBase,
+  Key extends RoutePath,
+  FullPath extends RoutePath,
+> = Routes<
+  RoutesWithHandlers,
+  HandlerContextExtra,
+  Key,
+  FullPath
+>;
+
+// export type NestedRoutes<
+//   ParentKey extends string,
+//   HandlerContextExtra extends HandlerContextBase,
+//   RoutesDefinition extends UnknownRouteNesting,
+// > = {
+//   [Key in keyof RoutesDefinition]: RoutesBranch<
+//     JoinStrings<ParentKey, EnsureString<Key>>,
+//     HandlerContextExtra
+//   >;
+// };
 
 /**
  * A record of route paths and {@link MatchHandler}s which are called when a match is
@@ -69,10 +161,25 @@ export type MatchHandler<T = unknown> = (
  * being able to prefix a route with a method name and the `@` sign. For
  * example a route only accepting `GET` requests would look like: `GET@/`.
  */
-// deno-lint-ignore ban-types
-export interface Routes<T = {}> {
-  [key: string]: Routes<T> | MatchHandler<T>;
-}
+export type Routes<
+  RoutesWithHandlers extends UnknownRouteNesting,
+  HandlerContextExtra extends HandlerContextBase,
+  ParentKey extends RoutePath,
+  FullPath extends RoutePath,
+> = {
+  [Key in keyof RoutesWithHandlers]:
+    RoutesWithHandlers[EnsureString<Key>] extends UnknownRouteNesting
+      ? RoutesBranch<
+        RoutesWithHandlers[EnsureString<Key>],
+        HandlerContextExtra,
+        EnsureString<Key>,
+        JoinStrings<FullPath, EnsureString<Key>>
+      >
+      : MatchHandler<
+        HandlerContextExtra,
+        ExtractPathMatch<JoinStrings<FullPath, EnsureString<Key>>>
+      >;
+};
 
 /**
  * The internal route object contains either a {@link RegExp} pattern or
@@ -80,10 +187,12 @@ export interface Routes<T = {}> {
  * URL. If a match is found for both the pattern and method the associated
  * {@link MatchHandler} is called.
  */
-// deno-lint-ignore ban-types
-export type InternalRoute<T = {}> = {
+export type InternalRoute<
+  PatternMatch extends Record<string, string>,
+  HandlerContextExtra extends HandlerContextBase,
+> = {
   pattern: RegExp | URLPattern;
-  methods: Record<string, MatchHandler<T>>;
+  methods: Record<string, MatchHandler<HandlerContextExtra, PatternMatch>>;
 };
 
 /**
@@ -94,28 +203,33 @@ export type InternalRoute<T = {}> = {
  * control over matches, for example by using a {@link RegExp} pattern instead
  * of a {@link URLPattern}.
  */
-// deno-lint-ignore ban-types
-export type InternalRoutes<T = {}> = InternalRoute<T>[];
+export type InternalRoutes<
+  PatternMatch extends Record<string, string>,
+  HandlerContextExtra extends HandlerContextBase,
+> = InternalRoute<
+  PatternMatch,
+  HandlerContextExtra
+>[];
 
 /**
  * Additional options for the {@link router} function.
  */
-export interface RouterOptions<T> {
+export interface RouterOptions<HandlerContextExtra extends HandlerContextBase> {
   /**
    * An optional property which contains a handler for anything that doesn't
    * match the `routes` parameter
    */
-  otherHandler?: Handler<T>;
+  otherHandler?: Handler<HandlerContextExtra>;
   /**
    * An optional property which contains a handler for any time it fails to run
    * the default request handling code
    */
-  errorHandler?: ErrorHandler<T>;
+  errorHandler?: ErrorHandler<HandlerContextExtra>;
   /**
    * An optional property which contains a handler for any time a method that
    * is not defined is used
    */
-  unknownMethodHandler?: UnknownMethodHandler<T>;
+  unknownMethodHandler?: UnknownMethodHandler<HandlerContextExtra>;
 }
 
 /**
@@ -150,9 +264,11 @@ export function defaultOtherHandler(_req: Request): Response {
  * The default error handler for the router. By default it responds with `null`
  * body and a status of 500 along with `console.error` logging the caught error.
  */
-export function defaultErrorHandler(
+export function defaultErrorHandler<
+  HandlerContextExtra extends HandlerContextBase,
+>(
   _req: Request,
-  _ctx: HandlerContext,
+  _ctx: HandlerContextExtra,
   err: unknown,
 ): Response {
   console.error(err);
@@ -167,9 +283,11 @@ export function defaultErrorHandler(
  * with `null` body, a status of 405 and the `Accept` header set to all
  * {@link KnownMethod known methods}.
  */
-export function defaultUnknownMethodHandler(
+export function defaultUnknownMethodHandler<
+  HandlerContextExtra extends HandlerContextBase,
+>(
   _req: Request,
-  _ctx: HandlerContext,
+  _ctx: HandlerContextExtra,
   knownMethods: KnownMethod[],
 ): Response {
   return new Response(null, {
@@ -194,17 +312,32 @@ function joinPaths(a: string, b: string): string {
   return a + b;
 }
 
+const isHandler = <
+  RoutePath extends string,
+  HandlerContextExtra extends HandlerContextBase,
+>(
+  handler: unknown,
+): handler is MatchHandler<HandlerContextExtra, ExtractPathMatch<RoutePath>> =>
+  typeof handler === "function";
+
 /**
  * Builds an {@link InternalRoutes} array from a {@link Routes} record.
  *
  * @param routes A {@link Routes} record
  * @returns The built {@link InternalRoutes}
  */
-export function buildInternalRoutes<T = unknown>(
-  routes: Routes<T>,
-  basePath = "/",
-): InternalRoutes<T> {
-  const internalRoutesRecord: Record<string, InternalRoute<T>> = {};
+export function buildInternalRoutes<
+  RoutePath extends string,
+  BaseRoutes extends Routes<BaseRoutes, HandlerContextExtra, RoutePath, "">,
+  HandlerContextExtra extends HandlerContextBase,
+>(
+  routes: BaseRoutes,
+  basePath: RoutePath,
+): InternalRoutes<ExtractPathMatch<RoutePath>, HandlerContextExtra> {
+  const internalRoutesRecord: Record<
+    string,
+    InternalRoute<ExtractPathMatch<RoutePath>, HandlerContextExtra>
+  > = {};
   for (const [route, handler] of Object.entries(routes)) {
     let [methodOrPath, path] = route.split(knownMethodRegex);
     let method = methodOrPath;
@@ -215,7 +348,7 @@ export function buildInternalRoutes<T = unknown>(
 
     path = joinPaths(basePath, path);
 
-    if (typeof handler === "function") {
+    if (isHandler<RoutePath, HandlerContextExtra>(handler)) {
       const r = internalRoutesRecord[path] ?? {
         pattern: new URLPattern({ pathname: path }),
         methods: {},
@@ -223,7 +356,15 @@ export function buildInternalRoutes<T = unknown>(
       r.methods[method] = handler;
       internalRoutesRecord[path] = r;
     } else {
-      const subroutes = buildInternalRoutes(handler, path);
+      const subroutes = buildInternalRoutes(
+        // handler as Routes<
+        //   Record<string, unknown>,
+        //   HandlerContextExtra,
+        //   RoutePath
+        // >,
+        handler as any,
+        path,
+      );
       for (const subroute of subroutes) {
         internalRoutesRecord[(subroute.pattern as URLPattern).pathname] ??=
           subroute;
@@ -254,25 +395,31 @@ export function buildInternalRoutes<T = unknown>(
  * @param options An object containing all of the possible configuration options
  * @returns A deno std compatible request handler
  */
-export function router<T = unknown>(
-  routes: Routes<T> | InternalRoutes<T>,
-  { otherHandler, errorHandler, unknownMethodHandler }: RouterOptions<T> = {
+export function router<
+  R extends Routes<R, HandlerContextExtra, "", "">,
+  HandlerContextExtra extends HandlerContextBase,
+>(
+  routes: R | InternalRoutes<never, HandlerContextExtra>,
+  { otherHandler, errorHandler, unknownMethodHandler }: RouterOptions<
+    HandlerContextExtra
+  > = {
     otherHandler: defaultOtherHandler,
     errorHandler: defaultErrorHandler,
     unknownMethodHandler: defaultUnknownMethodHandler,
   },
-): Handler<T> {
+): Handler<HandlerContextExtra> {
   otherHandler ??= defaultOtherHandler;
   errorHandler ??= defaultErrorHandler;
   unknownMethodHandler ??= defaultUnknownMethodHandler;
 
   const internalRoutes = Array.isArray(routes)
     ? routes
-    : buildInternalRoutes(routes);
+    : buildInternalRoutes(routes, "/");
 
   return async (req, ctx) => {
     try {
       for (const { pattern, methods } of internalRoutes) {
+        pattern;
         const res = pattern.exec(req.url);
         const groups = (pattern instanceof URLPattern
           ? ((res as URLPatternResult | null)?.pathname.groups as
@@ -287,12 +434,12 @@ export function router<T = unknown>(
         if (res !== null) {
           for (const [method, handler] of Object.entries(methods)) {
             if (req.method === method) {
-              return await handler(req, ctx, groups);
+              return await handler(req, ctx, groups as never);
             }
           }
 
           if (methods["any"]) {
-            return await methods["any"](req, ctx, groups);
+            return await methods["any"](req, ctx, groups as never);
           } else {
             return await unknownMethodHandler!(
               req,

--- a/test.ts
+++ b/test.ts
@@ -56,35 +56,35 @@ simpleRouter({
   },
 });
 
-Deno.test("typesafety - Split", ({ step }) => {
-  step("given empty string, should return empty array", () => {
+Deno.test("typesafety - Split", async ({ step }) => {
+  await step("given empty string, should return empty array", () => {
     Types.assertType<Types.IsExact<Split<"", "">, []>>(true);
     Types.assertType<Types.IsExact<Split<"", " ">, []>>(true);
     Types.assertType<Types.IsExact<Split<"", "/">, []>>(true);
   });
-  step(
+  await step(
     "given exact string to split character, should return one result",
     () => {
       Types.assertType<Types.IsExact<Split<" ", " ">, [""]>>(true);
       Types.assertType<Types.IsExact<Split<"/", "/">, [""]>>(true);
     },
   );
-  step("given prefixed split character, should return the prefix", () => {
+  await step("given prefixed split character, should return the prefix", () => {
     Types.assertType<Types.IsExact<Split<"a ", " ">, ["a"]>>(true);
     Types.assertType<Types.IsExact<Split<"b/", "/">, ["b"]>>(true);
   });
-  step("given suffixed split character, should return 2 results", () => {
+  await step("given suffixed split character, should return 2 results", () => {
     Types.assertType<Types.IsExact<Split<" a", " ">, ["", "a"]>>(true);
     Types.assertType<Types.IsExact<Split<"/b", "/">, ["", "b"]>>(true);
   });
-  step("given pathname should return array of defined strings", () => {
+  await step("given pathname should return array of defined strings", () => {
     type Param = "/this/is/test";
     type Expected = ["", "this", "is", "test"];
     type Result = Split<Param, "/">;
 
     Types.assertType<Types.IsExact<Result, Expected>>(true);
   });
-  step(
+  await step(
     "should split string into array of defined strings and preserve special characters",
     () => {
       type Param = "/this/is/test/:id/:item/:id/something/asd/asd/asd";
@@ -108,8 +108,8 @@ Deno.test("typesafety - Split", ({ step }) => {
   );
 });
 
-Deno.test("typesafety - FilterAndTrimPathParamsToStringUnion", ({ step }) => {
-  step("given empty array, should return empty union (never)", () => {
+Deno.test("typesafety - FilterAndTrimPathParamsToStringUnion", async ({ step }) => {
+  await step("given empty array, should return empty union (never)", () => {
     Types.assertType<
       Types.IsExact<FilterAndTrimPathParamsToStringUnion<[], "">, never>
     >(true);
@@ -123,27 +123,33 @@ Deno.test("typesafety - FilterAndTrimPathParamsToStringUnion", ({ step }) => {
       Types.IsExact<FilterAndTrimPathParamsToStringUnion<[], ":">, never>
     >(true);
   });
-  step("given array without match, should return empty union (never)", () => {
-    Types.assertType<
-      Types.IsExact<FilterAndTrimPathParamsToStringUnion<[""], "">, never>
-    >(true);
-    Types.assertType<
-      Types.IsExact<
-        FilterAndTrimPathParamsToStringUnion<["", "id", "asd", ""], " ">,
-        never
-      >
-    >(true);
-    Types.assertType<
-      Types.IsExact<
-        FilterAndTrimPathParamsToStringUnion<["something"], "/">,
-        never
-      >
-    >(true);
-    Types.assertType<
-      Types.IsExact<FilterAndTrimPathParamsToStringUnion<["aaaa"], ":">, never>
-    >(true);
-  });
-  step(
+  await step(
+    "given array without match, should return empty union (never)",
+    () => {
+      Types.assertType<
+        Types.IsExact<FilterAndTrimPathParamsToStringUnion<[""], "">, never>
+      >(true);
+      Types.assertType<
+        Types.IsExact<
+          FilterAndTrimPathParamsToStringUnion<["", "id", "asd", ""], " ">,
+          never
+        >
+      >(true);
+      Types.assertType<
+        Types.IsExact<
+          FilterAndTrimPathParamsToStringUnion<["something"], "/">,
+          never
+        >
+      >(true);
+      Types.assertType<
+        Types.IsExact<
+          FilterAndTrimPathParamsToStringUnion<["aaaa"], ":">,
+          never
+        >
+      >(true);
+    },
+  );
+  await step(
     "given array with matches, should return union of matches without the prefix",
     () => {
       Types.assertType<
@@ -166,7 +172,7 @@ Deno.test("typesafety - FilterAndTrimPathParamsToStringUnion", ({ step }) => {
       >(true);
     },
   );
-  step(
+  await step(
     "given array with duplicated matches, should return union of matches without the prefix and duplicates",
     () => {
       Types.assertType<
@@ -191,34 +197,37 @@ Deno.test("typesafety - FilterAndTrimPathParamsToStringUnion", ({ step }) => {
   );
 });
 
-Deno.test("typesafety - ExtractPathMatch", ({ step }) => {
-  step("given path without params, should return Record<never, string>", () => {
-    Types.assertType<
-      Types.IsExact<
-        ExtractPathMatch<
-          "/"
-        >,
-        Record<never, string>
-      >
-    >(true);
-    Types.assertType<
-      Types.IsExact<
-        ExtractPathMatch<
-          "/home"
-        >,
-        Record<never, string>
-      >
-    >(true);
-    Types.assertType<
-      Types.IsExact<
-        ExtractPathMatch<
-          "/api/v1/user"
-        >,
-        Record<never, string>
-      >
-    >(true);
-  });
-  step(
+Deno.test("typesafety - ExtractPathMatch", async ({ step }) => {
+  await step(
+    "given path without params, should return Record<never, string>",
+    () => {
+      Types.assertType<
+        Types.IsExact<
+          ExtractPathMatch<
+            "/"
+          >,
+          Record<never, string>
+        >
+      >(true);
+      Types.assertType<
+        Types.IsExact<
+          ExtractPathMatch<
+            "/home"
+          >,
+          Record<never, string>
+        >
+      >(true);
+      Types.assertType<
+        Types.IsExact<
+          ExtractPathMatch<
+            "/api/v1/user"
+          >,
+          Record<never, string>
+        >
+      >(true);
+    },
+  );
+  await step(
     "given path with params, should return record with params as keys",
     () => {
       Types.assertType<
@@ -249,8 +258,8 @@ Deno.test("typesafety - ExtractPathMatch", ({ step }) => {
   );
 });
 
-Deno.test("typesafety - HandlerContext", ({ step }) => {
-  step(
+Deno.test("typesafety - HandlerContext", async ({ step }) => {
+  await step(
     "given, should expose HandlerContextBase members",
     () => {
       Types.assertType<
@@ -263,7 +272,7 @@ Deno.test("typesafety - HandlerContext", ({ step }) => {
       >(true);
     },
   );
-  step(
+  await step(
     "given HandlerContextBase, should expose HandlerContextBase members",
     () => {
       Types.assertType<
@@ -276,7 +285,7 @@ Deno.test("typesafety - HandlerContext", ({ step }) => {
       >(true);
     },
   );
-  step(
+  await step(
     `given { something: number }, should expose HandlerContextBase members and the passed object member`,
     () => {
       type Given = {
@@ -295,8 +304,8 @@ Deno.test("typesafety - HandlerContext", ({ step }) => {
   );
 });
 
-Deno.test("typesafety - MatchHandler", ({ step }) => {
-  step(
+Deno.test("typesafety - MatchHandler", async ({ step }) => {
+  await step(
     `given "/" as route, should be empty on match`,
     () => {
       type Result = MatchHandler<
@@ -325,7 +334,7 @@ Deno.test("typesafety - MatchHandler", ({ step }) => {
       >(true);
     },
   );
-  step(
+  await step(
     `given "/home/:path/something/else/:view" as route, should expose path and view as params`,
     () => {
       type Result = MatchHandler<

--- a/test.ts
+++ b/test.ts
@@ -3,7 +3,437 @@ import {
   assertEquals,
   assertIsError,
 } from "https://deno.land/std@0.200.0/assert/mod.ts";
-import { router } from "./mod.ts";
+import {
+  type ExtractPathMatch,
+  type FilterAndTrimPathParamsToStringUnion,
+  type HandlerContext,
+  type HandlerContextBase,
+  type MatchHandler,
+  router,
+  type Routes,
+  type RoutesBranch,
+  type Split,
+} from "./mod.ts";
+import * as Types from "https://deno.land/std@0.220.1/testing/types.ts";
+
+type EmptyObject = Record<never, never>;
+
+// todo remove
+// it is just supersimple demo
+export function simpleRouter<
+  R extends Routes<R, HandlerContextExtra, "", "">,
+  HandlerContextExtra extends HandlerContextBase,
+>(routes: R) {
+}
+
+simpleRouter({
+  "/": (req, ctx, match) => new Response(),
+  "/home/:path/something/else/:view": (req, ctx, match) =>
+    new Response(`${match.path} ${match.view}`),
+  "/a": {
+    "/:type": {
+      "/details": (r, c, m) => new Response(m.type),
+    },
+  },
+  "/b": {
+    "/:bId": (r, c, m) => new Response(m.bId),
+  },
+  "/c": {
+    "/c": (r, c, m) => new Response(),
+  },
+  "/d": {
+    "/:dId": {
+      "/wow/its/aBig/:wildcardedRoute/:evenMoooooore": {
+        "/details": (r, c, m) => new Response(),
+        "/category": {
+          "/:categoryId": (r, c, m) =>
+            new Response(
+              `${m.categoryId} ${m.dId} ${m.evenMoooooore} ${m.wildcardedRoute}`,
+            ),
+        },
+      },
+    },
+  },
+});
+
+Deno.test("typesafety - Split", ({ step }) => {
+  step("given empty string, should return empty array", () => {
+    Types.assertType<Types.IsExact<Split<"", "">, []>>(true);
+    Types.assertType<Types.IsExact<Split<"", " ">, []>>(true);
+    Types.assertType<Types.IsExact<Split<"", "/">, []>>(true);
+  });
+  step(
+    "given exact string to split character, should return one result",
+    () => {
+      Types.assertType<Types.IsExact<Split<" ", " ">, [""]>>(true);
+      Types.assertType<Types.IsExact<Split<"/", "/">, [""]>>(true);
+    },
+  );
+  step("given prefixed split character, should return the prefix", () => {
+    Types.assertType<Types.IsExact<Split<"a ", " ">, ["a"]>>(true);
+    Types.assertType<Types.IsExact<Split<"b/", "/">, ["b"]>>(true);
+  });
+  step("given suffixed split character, should return 2 results", () => {
+    Types.assertType<Types.IsExact<Split<" a", " ">, ["", "a"]>>(true);
+    Types.assertType<Types.IsExact<Split<"/b", "/">, ["", "b"]>>(true);
+  });
+  step("given pathname should return array of defined strings", () => {
+    type Param = "/this/is/test";
+    type Expected = ["", "this", "is", "test"];
+    type Result = Split<Param, "/">;
+
+    Types.assertType<Types.IsExact<Result, Expected>>(true);
+  });
+  step(
+    "should split string into array of defined strings and preserve special characters",
+    () => {
+      type Param = "/this/is/test/:id/:item/:id/something/asd/asd/asd";
+      type Expected = [
+        "",
+        "this",
+        "is",
+        "test",
+        ":id",
+        ":item",
+        ":id",
+        "something",
+        "asd",
+        "asd",
+        "asd",
+      ];
+      type Result = Split<Param, "/">;
+
+      Types.assertType<Types.IsExact<Result, Expected>>(true);
+    },
+  );
+});
+
+Deno.test("typesafety - FilterAndTrimPathParamsToStringUnion", ({ step }) => {
+  step("given empty array, should return empty union (never)", () => {
+    Types.assertType<
+      Types.IsExact<FilterAndTrimPathParamsToStringUnion<[], "">, never>
+    >(true);
+    Types.assertType<
+      Types.IsExact<FilterAndTrimPathParamsToStringUnion<[], " ">, never>
+    >(true);
+    Types.assertType<
+      Types.IsExact<FilterAndTrimPathParamsToStringUnion<[], "/">, never>
+    >(true);
+    Types.assertType<
+      Types.IsExact<FilterAndTrimPathParamsToStringUnion<[], ":">, never>
+    >(true);
+  });
+  step("given array without match, should return empty union (never)", () => {
+    Types.assertType<
+      Types.IsExact<FilterAndTrimPathParamsToStringUnion<[""], "">, never>
+    >(true);
+    Types.assertType<
+      Types.IsExact<
+        FilterAndTrimPathParamsToStringUnion<["", "id", "asd", ""], " ">,
+        never
+      >
+    >(true);
+    Types.assertType<
+      Types.IsExact<
+        FilterAndTrimPathParamsToStringUnion<["something"], "/">,
+        never
+      >
+    >(true);
+    Types.assertType<
+      Types.IsExact<FilterAndTrimPathParamsToStringUnion<["aaaa"], ":">, never>
+    >(true);
+  });
+  step(
+    "given array with matches, should return union of matches without the prefix",
+    () => {
+      Types.assertType<
+        Types.IsExact<
+          FilterAndTrimPathParamsToStringUnion<
+            [":id"],
+            ":"
+          >,
+          "id"
+        >
+      >(true);
+      Types.assertType<
+        Types.IsExact<
+          FilterAndTrimPathParamsToStringUnion<
+            ["", ":id", "something", ":filterId"],
+            ":"
+          >,
+          "id" | "filterId"
+        >
+      >(true);
+    },
+  );
+  step(
+    "given array with duplicated matches, should return union of matches without the prefix and duplicates",
+    () => {
+      Types.assertType<
+        Types.IsExact<
+          FilterAndTrimPathParamsToStringUnion<
+            [
+              "",
+              ":id",
+              "something",
+              ":id",
+              ":filterId",
+              ":filterId",
+              "something",
+              ":id",
+            ],
+            ":"
+          >,
+          "id" | "filterId"
+        >
+      >(true);
+    },
+  );
+});
+
+Deno.test("typesafety - ExtractPathMatch", ({ step }) => {
+  step("given path without params, should return Record<never, string>", () => {
+    Types.assertType<
+      Types.IsExact<
+        ExtractPathMatch<
+          "/"
+        >,
+        Record<never, string>
+      >
+    >(true);
+    Types.assertType<
+      Types.IsExact<
+        ExtractPathMatch<
+          "/home"
+        >,
+        Record<never, string>
+      >
+    >(true);
+    Types.assertType<
+      Types.IsExact<
+        ExtractPathMatch<
+          "/api/v1/user"
+        >,
+        Record<never, string>
+      >
+    >(true);
+  });
+  step(
+    "given path with params, should return record with params as keys",
+    () => {
+      Types.assertType<
+        Types.IsExact<
+          ExtractPathMatch<
+            "/:path"
+          >,
+          Record<"path", string>
+        >
+      >(true);
+      Types.assertType<
+        Types.IsExact<
+          ExtractPathMatch<
+            "/home/:path/something/else/:view"
+          >,
+          Record<"path" | "view", string>
+        >
+      >(true);
+      Types.assertType<
+        Types.IsExact<
+          ExtractPathMatch<
+            "/api/v1/user/:userId/friends/:friendId/shares/:shareId"
+          >,
+          Record<"userId" | "friendId" | "shareId", string>
+        >
+      >(true);
+    },
+  );
+});
+
+Deno.test("typesafety - HandlerContext", ({ step }) => {
+  step(
+    "given, should expose HandlerContextBase members",
+    () => {
+      Types.assertType<
+        Types.IsExact<
+          HandlerContext,
+          {
+            remoteAddr: Deno.NetAddr;
+          }
+        >
+      >(true);
+    },
+  );
+  step(
+    "given HandlerContextBase, should expose HandlerContextBase members",
+    () => {
+      Types.assertType<
+        Types.IsExact<
+          HandlerContext<HandlerContextBase>,
+          {
+            remoteAddr: Deno.NetAddr;
+          }
+        >
+      >(true);
+    },
+  );
+  step(
+    `given { something: number }, should expose HandlerContextBase members and the passed object member`,
+    () => {
+      type Given = {
+        something: number;
+      };
+      type Expected = Given & {
+        remoteAddr: Deno.NetAddr;
+      };
+      Types.assertType<
+        Types.IsExact<
+          HandlerContext<Given>,
+          Expected
+        >
+      >(true);
+    },
+  );
+});
+
+Deno.test("typesafety - MatchHandler", ({ step }) => {
+  step(
+    `given "/" as route, should be empty on match`,
+    () => {
+      type Result = MatchHandler<
+        HandlerContextBase,
+        ExtractPathMatch<
+          "/"
+        >
+      >;
+      Types.assertType<
+        Types.IsExact<
+          Parameters<Result>,
+          [
+            Request,
+            {
+              remoteAddr: Deno.NetAddr;
+            },
+            EmptyObject,
+          ]
+        >
+      >(true);
+      Types.assertType<
+        Types.IsExact<
+          ReturnType<Result>,
+          Response | Promise<Response>
+        >
+      >(true);
+    },
+  );
+  step(
+    `given "/home/:path/something/else/:view" as route, should expose path and view as params`,
+    () => {
+      type Result = MatchHandler<
+        HandlerContextBase,
+        ExtractPathMatch<
+          "/home/:path/something/else/:view"
+        >
+      >;
+      Types.assertType<
+        Types.IsExact<
+          Parameters<Result>,
+          [
+            Request,
+            {
+              remoteAddr: Deno.NetAddr;
+            },
+            {
+              path: string;
+              view: string;
+            },
+          ]
+        >
+      >(true);
+      Types.assertType<
+        Types.IsExact<
+          ReturnType<Result>,
+          Response | Promise<Response>
+        >
+      >(true);
+    },
+  );
+});
+
+Deno.test("typesafety - Routes", () => {
+  type Result = Routes<
+    {
+      "/": unknown;
+      "/home/:path/something/else/:view": unknown;
+    },
+    HandlerContextBase,
+    "",
+    ""
+  >;
+  Types.assertType<
+    Types.IsExact<
+      Parameters<Result["/home/:path/something/else/:view"]>,
+      [
+        Request,
+        {
+          remoteAddr: Deno.NetAddr;
+        },
+        {
+          path: string;
+          view: string;
+        },
+      ]
+    >
+  >(true);
+  Types.assertType<
+    Types.IsExact<
+      Parameters<Result["/"]>,
+      [
+        Request,
+        {
+          remoteAddr: Deno.NetAddr;
+        },
+        EmptyObject,
+      ]
+    >
+  >(true);
+  Types.assertType<
+    Types.IsExact<
+      ReturnType<Result["/home/:path/something/else/:view"]>,
+      Response | Promise<Response>
+    >
+  >(true);
+  Types.assertType<
+    Types.IsExact<
+      ReturnType<Result["/"]>,
+      Response | Promise<Response>
+    >
+  >(true);
+});
+
+Deno.test("typesafety - router with direct typings", () => {
+  const r = router<
+    Routes<
+      {
+        "/": unknown;
+        "/home/:path/something/else/:view": unknown;
+      },
+      HandlerContextBase,
+      "",
+      ""
+    >,
+    HandlerContextBase
+  >({
+    "/": (req, ctx, match) => new Response(),
+    "/home/:path/something/else/:view": (req, ctx, match) => new Response(),
+  });
+});
+
+Deno.test("typesafety - router with inferred typings", () => {
+  const r = router({
+    "/": (req, ctx, match) => new Response(),
+    "/home/:path/something/else/:view": (req, ctx, match) => new Response(),
+  });
+});
 
 const TEST_CONN_INFO: Deno.ServeHandlerInfo = {
   remoteAddr: {
@@ -18,6 +448,9 @@ Deno.test("handlers", async ({ step }) => {
     await step("default", async () => {
       const route = router({
         "/test": () => new Response(),
+        "/test/more": (req, ctx, match) => {
+          return new Response();
+        },
       });
       let response: Response;
 
@@ -228,8 +661,13 @@ Deno.test("nesting", async ({ step }) => {
     const route = router({
       "/": () => new Response(),
       "/test/": {
-        "/abc": () => new Response(),
+        "/abc": (req, ctx, match) => new Response(),
         "/123": () => new Response(),
+      },
+      "/item": {
+        "/:itemId": {
+          "/details": (req, ctx, match) => new Response(),
+        },
       },
     });
     let response: Response;


### PR DESCRIPTION
Hi, I think the change is very visible when you open `/examples/typesafe_parameters.ts`.

I have few things missing in the typesafety of the internals - like few nevers that shouldn't be nevers and cleaning up few snippets that I was using to beat the typesystem to quickly check if everything is bueno.

I open this to get initial feedback if it is welcome or I should go and create something like safe fork packaged under different name (which is less preferred option for me).

I might add this to `URLPattern` itself in future, I will migrate rutt if my changes will get there, I felt like changing rutt will be far easier because the narrow scope of the lib.

Thanks!
